### PR TITLE
implicit auth doc reference changed to absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import { ImplicitAuthManager } from '@bcgov/common-web-utils';
 ```
 ### Further Documentation
 
-[Implicit Auth Manager](./docs/ImplicitAuthManger.md)
+[Implicit Auth Manager](https://github.com/bcgov/common-web-utils/blob/master/docs/ImplicitAuthManger.md)
 
 ## Project Status / Goals / Roadmap
 


### PR DESCRIPTION
This change is so that the doc reference is visible in the npmjs.com view of this package. 