### PR TITLE
Add isMap to TypeCheck

### DIFF
--- a/__tests__/TypeCheck.test.js
+++ b/__tests__/TypeCheck.test.js
@@ -60,13 +60,17 @@ describe('TypeCheck class', () => {
   it('checks for object against value', () => {
     const obj1 = String;
     const obj2 = Function;
+    const obj3 = Map;
     const value1 = 'true';
     const value2 = () => null;
+    const value3 = new Map();
 
     expect(TypeCheck.isA(obj1, value1)).toBe(true);
     expect(TypeCheck.isA(obj1, value2)).toBe(false);
     expect(TypeCheck.isA(obj2, value2)).toBe(true);
     expect(TypeCheck.isA(obj2, value1)).toBe(false);
+    expect(TypeCheck.isA(obj3, value1)).toBe(false);
+    expect(TypeCheck.isA(obj3, value3)).toBe(true);
   });
 
   it('can check for an array of strings', () => {
@@ -88,5 +92,10 @@ describe('TypeCheck class', () => {
   it('returns false if array but one value isn\'t correct', () => {
     const array = [1, '2', 3];
     expect(TypeCheck.isArrayOf(Number, array)).toBe(false);
+  });
+
+  it('checks for Map', () => {
+    expect(TypeCheck.isMap(new Map())).toBe(true);
+    expect(TypeCheck.isMap({})).toBe(false);
   });
 });

--- a/docs/TypeCheck.md
+++ b/docs/TypeCheck.md
@@ -23,6 +23,7 @@ if(TypeCheck.isFunction(notAFunction)) {
 ### static methods
 ```javascript
   TypeCheck.isObject(value) { boolean }  // TypeCheck.isObject({});
+  TypeCheck.isMap(value) { boolean }  // TypeCheck.isObject({});
   TypeCheck.isString(value) { boolean } // TypeCheck.isString('hello world');
   TypeCheck.isArray(value) { boolean }  // TypeCheck.isArray([1, 2, 3]);
   TypeCheck.isFunction(value) { boolean } // TypeCheck.isFunction(() => null);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "0.4.2",
+  "version": "0.5.2",
   "description": "",
   "engine": "node 8.4.0",
   "main": "dist/index.js",

--- a/src/libs/TypeCheck.js
+++ b/src/libs/TypeCheck.js
@@ -59,6 +59,10 @@ export default class TypeCheck {
     return TypeCheck.getClass(object) === 'Date';
   }
 
+  static isMap(object) {
+    return TypeCheck.getClass(object) === 'Map';
+  }
+
   static isRegExp(object) {
     return TypeCheck.getClass(object) === 'RegExp';
   }
@@ -71,18 +75,18 @@ export default class TypeCheck {
 
   /**
    * helper to match an object with a referer
-   * @param {Object} refererObject
+   * @param {Object} ObjectConstructor one of the javascript data type constructors
    * @param {Object} object
    * @returns {Boolean}
    * TypeCheck.isA(String, "this is a string"); => true
    * TypeCheck.isA(Array, [1, 3, 5]); => true
    */
-  static isA(objectConstructor, object) {
-    if (!TypeCheck.isFunction(objectConstructor)) {
+  static isA(ObjectContstructor, object) {
+    if (!TypeCheck.isFunction(ObjectContstructor)) {
       throw new Error(
         'objectContructor must be one of the javascript object constructors: String, Function, Boolean etc.'
       );
     }
-    return TypeCheck.getClass(object) === TypeCheck.getClass(objectConstructor());
+    return TypeCheck.getClass(object) === TypeCheck.getClass(new ObjectContstructor());
   }
 }


### PR DESCRIPTION
added isMap utility function, also corrected a bug where `TypeCheck.isA` would not work with Object constructors that required the `new` keyword.

Fixes #29