### PR TITLE
Bug Fix for handling redirects in safari

### DIFF
--- a/__tests__/ImplicitAuthManager.test.js
+++ b/__tests__/ImplicitAuthManager.test.js
@@ -274,6 +274,24 @@ describe('Implicit Auth Manager Class', () => {
     });
   });
 
+  describe('Redirect Count State', () => {
+    test('redirect counts can be incremented and deleted', () => {
+      ImplicitAuthManager.incrementRedirectCountFromLocal();
+      const count = getDataFromLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey);
+      expect(count).toBe(1);
+
+      ImplicitAuthManager.incrementRedirectCountFromLocal();
+      const count2 = getDataFromLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey);
+      expect(count2).toBe(2);
+
+      ImplicitAuthManager.deleteRedirectCountFromLocal();
+      const count3 = getDataFromLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey);
+      expect(count3).not.toBeDefined();
+
+    })
+  })
+
+
   describe('Nonce/Request Key generation/management', () => {
     // test('creating request keys are relatively unique', () => {
     //   const config = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.6",
+  "version": "1.0.7-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.6-2",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.6-1",
+  "version": "1.0.6-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.5",
+  "version": "1.0.6-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.6-0",
+  "version": "1.0.6-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "scripts": {
     "build": "babel src --out-dir dist",
+    "prepare": "babel src --out-dir dist",
     "test": "NODE_ENV=test jest __tests__ --env=jsdom",
     "test:watch": "NODE_ENV=test jest __tests__ --watch --env=jsdom",
     "test:lint": "eslint --env node --ext .js src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.6",
+  "version": "1.0.7-0",
   "description": "A common set of web utils that can be leveraged for front end applications. ",
   "engine": "node 8.4.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.6-0",
+  "version": "1.0.6-1",
   "description": "A common set of web utils that can be leveraged for front end applications. ",
   "engine": "node 8.4.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.6-2",
+  "version": "1.0.6",
   "description": "A common set of web utils that can be leveraged for front end applications. ",
   "engine": "node 8.4.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "engine": "node 8.4.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.6-1",
+  "version": "1.0.6-2",
   "description": "A common set of web utils that can be leveraged for front end applications. ",
   "engine": "node 8.4.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.7-0",
+  "version": "1.0.6-4",
   "description": "A common set of web utils that can be leveraged for front end applications. ",
   "engine": "node 8.4.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/common-web-utils",
-  "version": "1.0.5",
+  "version": "1.0.6-0",
   "description": "A common set of web utils that can be leveraged for front end applications. ",
   "engine": "node 8.4.0",
   "main": "dist/index.js",

--- a/src/libs/ImplicitAuthManager.js
+++ b/src/libs/ImplicitAuthManager.js
@@ -115,7 +115,6 @@ export class ImplicitAuthManager {
     };
     this.baseAuthEndpoint = this.createBaseAuthEndpointFromConfig();
     this.baseLogoutEndpoint = this.createBaseLogoutEndpointFromConfig();
-    this.redirectCountLocalStorageKey = 'iamRedirectCount';
   }
 
   // eslint-disable-next-line
@@ -210,22 +209,22 @@ export class ImplicitAuthManager {
   }
 
   static returnOrCreateRedirectCountFromLocal() {
-    let count = getDataFromLocalStorage(this.redirectCountLocalStorageKey);
+    let count = getDataFromLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey);
     if (!count) {
       count = 0;
-      saveDataInLocalStorage(this.redirectCountLocalStorageKey, count);
+      saveDataInLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey, count);
     }
 
     return count;
   }
 
   static deleteRedirectCountFromLocal() {
-    deleteDataFromLocalStorage(this.redirectCountLocalStorageKey);
+    deleteDataFromLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey);
   }
 
   static incrementRedirectCountFromLocal() {
     const count = this.returnOrCreateRedirectCountFromLocal();
-    saveDataInLocalStorage(this.redirectCountLocalStorageKey, count + 1);
+    saveDataInLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey, count + 1);
   }
 
   clearAuthLocalStorage() {
@@ -527,6 +526,7 @@ export class ImplicitAuthManager {
         const ssoLoginURI = this.getSSOLoginURIForPageLoadRedirect();
         // eslint-disable-next-line
         ImplicitAuthManager.incrementRedirectCountFromLocal();
+
         window.location.replace(ssoLoginURI);
       }
     } else {
@@ -581,7 +581,8 @@ export class ImplicitAuthManager {
     // eslint-disable-next-line
     const idToken = this.getIdTokenFromHash(hash);
     const error = this.getErrorFromHash(hash);
-    const redirectCount = getDataFromLocalStorage(this.redirectCountLocalStorageKey) / 1;
+    const redirectCount =
+      getDataFromLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey) / 1;
     // eslint-disable-next-line
     return idToken !== null || accessToken !== null || error !== null || redirectCount > 0;
   }
@@ -620,3 +621,5 @@ export class ImplicitAuthManager {
     });
   }
 }
+
+ImplicitAuthManager.redirectCountLocalStorageKey = 'iamRedirectCount';

--- a/src/libs/ImplicitAuthManager.js
+++ b/src/libs/ImplicitAuthManager.js
@@ -210,7 +210,8 @@ export class ImplicitAuthManager {
 
   static returnOrCreateRedirectCountFromLocal() {
     let count = getDataFromLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey);
-    if (!count) {
+
+    if (count === undefined) {
       count = 0;
       saveDataInLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey, count);
     }
@@ -512,6 +513,7 @@ export class ImplicitAuthManager {
 
   handleOnPageLoad() {
     const redirectCount = ImplicitAuthManager.returnOrCreateRedirectCountFromLocal();
+
     if (this.isAuthenticated()) {
       // set expiry timers
       this.setTokenExpiryTimers();
@@ -550,8 +552,8 @@ export class ImplicitAuthManager {
       }
       // clear nonce
       this.clearNonce();
+      ImplicitAuthManager.deleteRedirectCountFromLocal();
     }
-    ImplicitAuthManager.deleteRedirectCountFromLocal();
   }
 
   // eslint-disable-next-line
@@ -581,10 +583,9 @@ export class ImplicitAuthManager {
     // eslint-disable-next-line
     const idToken = this.getIdTokenFromHash(hash);
     const error = this.getErrorFromHash(hash);
-    const redirectCount =
-      getDataFromLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey) / 1;
+    const redirectCount = getDataFromLocalStorage(ImplicitAuthManager.redirectCountLocalStorageKey);
     // eslint-disable-next-line
-    return idToken !== null || accessToken !== null || error !== null || redirectCount > 0;
+    return idToken !== null || accessToken !== null || error !== null || (redirectCount && redirectCount > 0);
   }
 
   isAuthenticated() {

--- a/src/libs/ImplicitAuthManager.js
+++ b/src/libs/ImplicitAuthManager.js
@@ -141,10 +141,6 @@ export class ImplicitAuthManager {
     return this.config.redirectURI || window.location.origin;
   }
 
-  set redirectURI(uri) {
-    this.redirectURI = uri;
-  }
-
   get ssoLogoutURI() {
     return this.getSSOLogoutURI();
   }
@@ -468,14 +464,16 @@ export class ImplicitAuthManager {
     return encodeURI(logoutURI);
   }
 
-  getSSOLoginURI(prompt = 'login') {
+  getSSOLoginURI(prompt = 'login', uri = '') {
     if (!ImplicitAuthManager.validPromptTypes().includes(prompt)) {
       throw new Error(`Prompt type must one of ${ImplicitAuthManager.validPromptTypes()}`);
     }
 
     const apiIntentions = ImplicitAuthManager.validAPIIntentions();
     const uriConf = this.config;
-    const redirectURI = this.getSSORedirectURI(apiIntentions.LOGIN);
+
+    const redirectURI = uri && isString(uri) ? uri : this.getSSORedirectURI(apiIntentions.LOGIN);
+
     const nonce = this.createNonce();
     const kcIDPHint = uriConf.kcIDPHint ? `&kc_idp_hint=${uriConf.kcIDPHint}` : '';
     const loginURI = `${this.baseAuthEndpoint}?response_type=${

--- a/src/libs/ImplicitAuthManager.js
+++ b/src/libs/ImplicitAuthManager.js
@@ -581,8 +581,9 @@ export class ImplicitAuthManager {
     // eslint-disable-next-line
     const idToken = this.getIdTokenFromHash(hash);
     const error = this.getErrorFromHash(hash);
+    const redirectCount = getDataFromLocalStorage(this.redirectCountLocalStorageKey) / 1;
     // eslint-disable-next-line
-    return idToken !== null || accessToken !== null || error !== null;
+    return idToken !== null || accessToken !== null || error !== null || redirectCount > 0;
   }
 
   isAuthenticated() {

--- a/src/libs/ImplicitAuthManager.js
+++ b/src/libs/ImplicitAuthManager.js
@@ -141,6 +141,10 @@ export class ImplicitAuthManager {
     return this.config.redirectURI || window.location.origin;
   }
 
+  set redirectURI(uri) {
+    this.redirectURI = uri;
+  }
+
   get ssoLogoutURI() {
     return this.getSSOLogoutURI();
   }


### PR DESCRIPTION
Safari sometimes strips hash fragments from urls which can cause issues when trying to parse and detect redirect. The process for detecting redirects is now done primarily through a local storage state. 